### PR TITLE
CxSCA-Remediation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,31 +1,30 @@
 {
-    "name"        : "DroneOlympics"
-  , "version"     : "0.0.1"
-  , "homepage"    : "http://droneolympics.com/"
-  , "description" : "DroneOlympics"
-  , "author"      : "Christian Sanz <chris@sanz.io>"
-  , "dependencies": {
-        "async"             : "0.1.18"
-      , "express"           : "2.5.4"
-      , "express-messages"  : "0.0.x"
-      , "express-resource"  : "0.2.4"
-      , "express-mongoose"  : "0.0.x"
-      , "express-expose"    : "0.2.2"
-      , "stylus"            : "0.13.x"
-      , "mongoose"          : "2.5.10"
-      , "jade"              : "0.25.x"
-      , "stylus"            : "0.22.x"
-      , "nib"               : "0.3.x"
-      , "pusher"            : "0.0.x"
-      , "nodemailer"        : "0.3.21"
-      , "underscore"        : "1.1.x"
-      , "request"           : "2.9.153"
-      , "winston"           : "0.5.10"
-      , "kue"               : "0.3.4"
-    }
-  , "main"    : "./index.js"
-  , "engines" : { 
-      "node": "0.6.x" 
-    , "npm" : "1.0.x"
-    }
+  "name": "DroneOlympics",
+  "version": "0.0.1",
+  "homepage": "http://droneolympics.com/",
+  "description": "DroneOlympics",
+  "author": "Christian Sanz <chris@sanz.io>",
+  "dependencies": {
+    "async": "0.1.18",
+    "express": "3.12.0",
+    "express-messages": "0.0.x",
+    "express-resource": "0.2.4",
+    "express-mongoose": "0.0.x",
+    "express-expose": "0.2.2",
+    "stylus": "0.22.x",
+    "mongoose": "4.13.20",
+    "jade": "0.25.x",
+    "nib": "0.3.x",
+    "pusher": "0.0.x",
+    "nodemailer": "0.3.21",
+    "underscore": "1.1.x",
+    "request": "2.47.0",
+    "winston": "0.5.10",
+    "kue": "0.3.4"
+  },
+  "main": "./index.js",
+  "engines": {
+    "node": "0.6.x",
+    "npm": "1.0.x"
+  }
 }


### PR DESCRIPTION
### Packages updated by CxSCA-Remediation

**package.json:**
 - express: 2.5.4 🠚 3.12.0 (Fixes: CVE-2014-6393)
 - mongoose: 2.5.10 🠚 4.13.20 (Fixes: CVE-2019-17426)
 - request: 2.9.153 🠚 2.47.0 (Fixes: CVE-2017-16026)
